### PR TITLE
Add otel collector to mix

### DIFF
--- a/conf.d/openmetrics.d/conf.yaml
+++ b/conf.d/openmetrics.d/conf.yaml
@@ -3,7 +3,7 @@ init_config:
   service: spicedb
 
 instances:
-  - openmetrics_endpoint: "http://spicedb:9090/metrics"
+  - openmetrics_endpoint: "http://otel-collector:9090/metrics"
     # Prefixes all of the metrics scraped by DD with `spicedb.`
     namespace: "spicedb"
     metrics:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,11 @@ services:
       - "./conf.d:/conf.d"
       - "./datadog.yaml:/datadog.yaml"
 
+  otel-collector:
+    image: "otel/opentelemetry-collector-contrib"
+    volumes:
+      - "./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml"
+
   spicedb:
     image: "authzed/spicedb:v1.38.1"
     command: "serve"

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -1,0 +1,29 @@
+---
+receivers:
+  prometheus:
+    config:
+      scrape_configs:
+        - job_name: "otel-collector"
+          scrape_interval: "5s"
+          static_configs:
+            - targets: ["spicedb:9090"]
+
+processors:
+  # TODO: filter
+  batch:
+  memory_limiter:
+    check_interval: 5s
+    limit_mib: 4000
+    spike_limit_mib: 500
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:9090"
+    enable_open_metrics: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [prometheus]
+      processors: [memory_limiter, batch]
+      exporters: [prometheus]

--- a/otel-collector-crd.yaml
+++ b/otel-collector-crd.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: datadog-export
+  namespace: authzed-monitoring
+spec:
+  config:
+    receivers:
+      prometheus:
+        config:
+          scrape_configs:
+            - job_name: "otel-collector"
+              scrape_interval: "5s"
+              static_configs:
+                - targets: ["thanos-federate-proxy.authzed-system:9090"]
+              metrics_path: "/federate"
+              params:
+                'match[]':
+                  # TODO: this could theoretically just be "all"
+                  -  '{__name__=~"spicedb_.*|grpc_server_.*|process_cpu_seconds_total|process_virtual_memory_bytes",authzed_com_permission_system="thumper-crdb"}'
+    processors:
+      # TODO: filter
+      batch:
+        send_batch_max_size: 1000
+        send_batch_size: 100
+        timeout: 10s
+      memory_limiter:
+        check_interval: 5s
+        limit_mib: 4000
+        spike_limit_mib: 500
+
+    exporters:
+      datadog/exporter:
+        api:
+          site: datadoghq.com
+          # TODO: Remove this
+          key: fb72de04adcdd9dc95856ee966cd3c83
+
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+          processors: [memory_limiter, batch]
+          exporters: [datadog/exporter]
+      telemetry:
+        logs:
+          development: true


### PR DESCRIPTION
## Description
This adds the opentelemetry collector to the mix, to demonstrate how we might have the collector act as a middleman and reduce the number of datadog agents that you need to run by aggregating the metrics.

Note that this doesn't currently have multiple SpiceDB instances being scraped, but I'll probably noodle on that soon.

## Changes
* Point Datadog at the otel collector container
* Set up the otel collector container in Datadog
* Add configuration for otel collector and mount in container

## Testing
Bring it up and see that everything works.